### PR TITLE
adds content security policy

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -3,6 +3,8 @@
   "name": "Color Annihlator",
   "description": "This extension gradually takes color away from the current web page",
   "version": "1.0",
+  "content_security_policy": "script-src 'self' 'sha256-yAMSYBzx73/JnK0CAWgXoxDOm3c7c+qsfVHlIlVI1nM='; object-src 'self'",
+
 
   "content_scripts": [
     {
@@ -16,7 +18,8 @@
   },
   
   "permissions": [
-    "activeTab"
+    "activeTab",
+    "tabs"
   ],
   "icons": {"16": "skully16.png",
             "48": "skully48.png",


### PR DESCRIPTION
the inline script in sandboxed.html can only run if there is a hash 'sha-256 etc' in the listed in the content security policy of the extension.
this hash is unique to the script so changing the script will prevent that code from running